### PR TITLE
update to latest style guide for the nav menu to have more mb

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "frequency-xyz",
       "version": "0.0.1",
       "dependencies": {
-        "@frequency-chain/style-guide": "^0.1.22",
+        "@frequency-chain/style-guide": "^0.1.24",
         "@lottiefiles/dotlottie-web": "^0.37.0-beta.8"
       },
       "devDependencies": {
@@ -697,10 +697,9 @@
       "license": "MIT"
     },
     "node_modules/@frequency-chain/style-guide": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/@frequency-chain/style-guide/-/style-guide-0.1.22.tgz",
-      "integrity": "sha512-yjIONmzy7L70lNOA42DQTRSUp8qgnBrbjIdRczftSGA9CZEklfMwcnoJicanlR2sojIawH1fKgUePJOpolrGBA==",
-      "license": "Apache-2.0",
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/@frequency-chain/style-guide/-/style-guide-0.1.24.tgz",
+      "integrity": "sha512-0fjSLVVCvI6WIjlL7gr1ZvcGJNRZuPnDJeKK0jOirZLWX3D9NGGfHoxuxg7wmawSQQ/19JgGaKBdDsMyXor0Ow==",
       "dependencies": {
         "@storybook/addons": "^7.6.17",
         "bits-ui": "^0.21.16",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@frequency-chain/style-guide": "^0.1.22",
+    "@frequency-chain/style-guide": "^0.1.24",
     "@lottiefiles/dotlottie-web": "^0.37.0-beta.8"
   }
 }


### PR DESCRIPTION
# Description

- update to latest style guide for the nav menu to have more `mb`

- Closes #99 

## Screenshot(s)

- Updated the `mb` from 20px to 48px

<img width="371" alt="Screenshot 2024-11-21 at 8 41 04 AM" src="https://github.com/user-attachments/assets/2f0e812a-9b29-42f1-ab6d-3199ede674ad">
