### PR TITLE
update metrics to include AT Protocol Content Feed Users

### DIFF
--- a/src/components/Sections/Top/MsaCounter.svelte
+++ b/src/components/Sections/Top/MsaCounter.svelte
@@ -39,15 +39,13 @@
       clearTimeout(showStatic);
       clearInterval(intervalId);
     };
-
-    // TODO AT Protocol Content Feed Users + New User Activations
   });
 </script>
 
 <div
   class="-mt-[1px] bg-black px-4 py-3 text-[40px] leading-none text-white sm:text-[50px] md:text-[calc(100vw/23)] xl:text-[75px]"
 >
-  <div class="text-right text-[12px] font-semibold uppercase md:text-[0.25em]">New User Activations</div>
+  <div class="text-right text-[12px] font-semibold uppercase md:text-[0.25em]">User Data Secured For</div>
   <div class="font-title invisible font-bold tracking-wide">
     {widthMsaCount}
   </div>

--- a/src/components/Sections/Top/MsaCounter.svelte
+++ b/src/components/Sections/Top/MsaCounter.svelte
@@ -1,24 +1,28 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte';
   import { fade } from 'svelte/transition';
-  import { getMsaCount } from '$lib/metrics';
+  import { getMsaCount, getTotUsersCount } from '$lib/metrics';
 
-  let msaCount = $state(1_333_820);
+  let msaCount = $state(2_098_604);
+  let totUsersCount = $state(11_298_183);
   const msaCountAnimationMs = 300;
   let updateIntervalMs = 5000;
   let showMsaCount = $state(false);
-  let displayMsaCount = $derived(msaCount.toLocaleString());
+  let displayMsaCount = $derived((msaCount + totUsersCount).toLocaleString());
   // Make this as long as possible for the variable width font handling
   let widthMsaCount = $derived(displayMsaCount.replaceAll(/[0-9]/g, '8'));
 
   async function updateMsaCount(skipAnimation = false) {
     const newMsaCount = await getMsaCount();
-    if (newMsaCount !== msaCount) {
+    const newTotUsersCount = await getTotUsersCount();
+
+    if (newMsaCount !== msaCount || newTotUsersCount !== totUsersCount) {
       // Toggle the animation classes so it is reapplied
       showMsaCount = skipAnimation ? showMsaCount : false;
       await tick();
       await new Promise((r) => setTimeout(r, msaCountAnimationMs + 100));
       msaCount = newMsaCount;
+      totUsersCount = newTotUsersCount;
       showMsaCount = true;
     }
   }
@@ -35,23 +39,25 @@
       clearTimeout(showStatic);
       clearInterval(intervalId);
     };
+
+    // TODO AT Protocol Content Feed Users + New User Activations
   });
 </script>
 
 <div
-  class="bg-black px-4 py-3 text-[40px] leading-none text-white sm:text-[50px] md:text-[calc(100vw/23)] xl:text-[75px]"
+  class="-mt-[1px] bg-black px-4 py-3 text-[40px] leading-none text-white sm:text-[50px] md:text-[calc(100vw/23)] xl:text-[75px]"
 >
+  <div class="text-right text-[12px] font-semibold uppercase md:text-[0.25em]">New User Activations</div>
+  <div class="font-title invisible font-bold tracking-wide">
+    {widthMsaCount}
+  </div>
   {#if showMsaCount}
     <div
       in:fade={{ duration: msaCountAnimationMs }}
       out:fade={{ duration: msaCountAnimationMs }}
-      class="font-title absolute left-0 w-full px-4 text-right font-bold tracking-wide"
+      class="font-title absolute top-[28px] left-0 w-full px-4 text-right font-bold tracking-wide"
     >
       {displayMsaCount}
     </div>
   {/if}
-  <div class="font-title invisible font-bold tracking-wide">
-    {widthMsaCount}
-  </div>
-  <div class="text-right text-[12px] font-semibold uppercase md:text-[0.25em]">New User Activations</div>
 </div>

--- a/src/components/Sections/Top/SecuredUsersCounter.svelte
+++ b/src/components/Sections/Top/SecuredUsersCounter.svelte
@@ -5,25 +5,28 @@
 
   let msaCount = $state(2_098_604);
   let totUsersCount = $state(11_298_183);
-  const msaCountAnimationMs = 300;
-  let updateIntervalMs = 5000;
-  let showMsaCount = $state(false);
-  let displayMsaCount = $derived((msaCount + totUsersCount).toLocaleString());
-  // Make this as long as possible for the variable width font handling
-  let widthMsaCount = $derived(displayMsaCount.replaceAll(/[0-9]/g, '8'));
 
-  async function updateMsaCount(skipAnimation = false) {
+  const animationMs = 300;
+  let updateIntervalMs = 5000;
+
+  let showSecuredUsersCount = $state(false);
+
+  let displaySecuredUsersCount = $derived((msaCount + totUsersCount).toLocaleString());
+  // Make this as long as possible for the variable width font handling
+  let widthSecuredUsersCount = $derived(displaySecuredUsersCount.replaceAll(/[0-9]/g, '8'));
+
+  async function updateSecuredUsersCount(skipAnimation = false) {
     const newMsaCount = await getMsaCount();
     const newTotUsersCount = await getTotUsersCount();
 
     if (newMsaCount !== msaCount || newTotUsersCount !== totUsersCount) {
       // Toggle the animation classes so it is reapplied
-      showMsaCount = skipAnimation ? showMsaCount : false;
+      showSecuredUsersCount = skipAnimation ? showSecuredUsersCount : false;
       await tick();
-      await new Promise((r) => setTimeout(r, msaCountAnimationMs + 100));
+      await new Promise((r) => setTimeout(r, animationMs + 100));
       msaCount = newMsaCount;
       totUsersCount = newTotUsersCount;
-      showMsaCount = true;
+      showSecuredUsersCount = true;
     }
   }
 
@@ -31,10 +34,10 @@
     // Setup number and skip the animation first time
     // Try to prevent showing the static number if we can get it in under 1000ms
     const showStatic = setTimeout(() => {
-      if (!showMsaCount) showMsaCount = true;
+      if (!showSecuredUsersCount) showSecuredUsersCount = true;
     }, 1000);
-    updateMsaCount(true);
-    const intervalId = setInterval(updateMsaCount, updateIntervalMs);
+    updateSecuredUsersCount(true);
+    const intervalId = setInterval(updateSecuredUsersCount, updateIntervalMs);
     return () => {
       clearTimeout(showStatic);
       clearInterval(intervalId);
@@ -47,15 +50,15 @@
 >
   <div class="text-right text-[12px] font-semibold uppercase md:text-[0.25em]">User Data Secured For</div>
   <div class="font-title invisible font-bold tracking-wide">
-    {widthMsaCount}
+    {widthSecuredUsersCount}
   </div>
-  {#if showMsaCount}
+  {#if showSecuredUsersCount}
     <div
-      in:fade={{ duration: msaCountAnimationMs }}
-      out:fade={{ duration: msaCountAnimationMs }}
+      in:fade={{ duration: animationMs }}
+      out:fade={{ duration: animationMs }}
       class="font-title absolute top-[28px] left-0 w-full px-4 text-right font-bold tracking-wide"
     >
-      {displayMsaCount}
+      {displaySecuredUsersCount}
     </div>
   {/if}
 </div>

--- a/src/components/Sections/Top/Top.svelte
+++ b/src/components/Sections/Top/Top.svelte
@@ -2,7 +2,7 @@
   import SectionWrapper from './../SectionWrapper.svelte';
   import SlideIn from '../../SlideIn.svelte';
   import HomeAnimation from '../../Animations/Home.svelte';
-  import MsaCounter from './MsaCounter.svelte';
+  import SecuredUsersCounter from './SecuredUsersCounter.svelte';
 
   // top-[calc(255px-((100vw-1300px)*0.075))] !?!?!?!
   // That's to be able to responsively handle the movement of the animation
@@ -17,7 +17,7 @@
       class="math xs:left-[18%] absolute top-[25%] left-[20px] md:top-[calc(85px-((100vw-1300px)*0.075))] md:left-[23%] lg:top-[calc(250px-((100vw-1300px)*0.075))] xl:top-[220px]"
     >
       <SlideIn>
-        <MsaCounter />
+        <SecuredUsersCounter />
       </SlideIn>
     </div>
   </div>

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -27,3 +27,17 @@ export async function getMsaCount() {
   const response = await (await fetch(providerUriList[0], options)).json();
   return hexToBigEndian(response.result);
 }
+
+export async function getTotUsersCount() {
+  const defaultValue = 11298183;
+
+  try {
+    const response = await fetch('https://portal.atproto.projectliberty.io/stats/totusers');
+    if (!response.ok) throw '';
+    const totusers = await response.json();
+    const n = Number(totusers) || defaultValue;
+    return n;
+  } catch {
+    return defaultValue;
+  }
+}


### PR DESCRIPTION
# Description
- include AT Protocol Content Feed Users in the total users number on the home page

## Screenshot(s)
<img width="1227" height="739" alt="Screenshot 2025-09-09 at 2 42 34 PM" src="https://github.com/user-attachments/assets/e151c1b2-a2a5-4131-9fcf-128193835c6e" />


# How to Test?

Please describe how to test that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

1. Pull and run locally
2. See that the count is updating. Should be around 13,000,000+
